### PR TITLE
fix(worker): filter tool downloads by CPU architecture

### DIFF
--- a/oasm/worker_download_tools.go
+++ b/oasm/worker_download_tools.go
@@ -59,14 +59,16 @@ func (c *Client) WorkerDownloadTools(ctx context.Context) error {
 		osKey = "macos"
 	}
 
+	archKey := runtime.GOARCH
+
 	var osTools []string
 	switch osKey {
 	case "linux":
-		osTools = registry.Linux
+		osTools = filterByArch(registry.Linux, archKey)
 	case "windows":
-		osTools = registry.Windows
+		osTools = filterByArch(registry.Windows, archKey)
 	case "macos":
-		osTools = registry.Macos
+		osTools = filterByArch(registry.Macos, archKey)
 	default:
 		return fmt.Errorf("unsupported OS: %s", osKey)
 	}
@@ -365,4 +367,21 @@ func saveToolState(path string, state map[string][]string) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o644)
+}
+
+// filterByArch filters a list of tool URLs to only those matching the current
+// CPU architecture. It looks for the GOARCH string (e.g. "arm64", "amd64") in
+// the filename. If no files match the current arch, all files are returned as a
+// fallback so existing single-arch deployments continue to work.
+func filterByArch(tools []string, arch string) []string {
+	var matched []string
+	for _, tool := range tools {
+		if strings.Contains(filepath.Base(tool), arch) {
+			matched = append(matched, tool)
+		}
+	}
+	if len(matched) == 0 {
+		return tools
+	}
+	return matched
 }


### PR DESCRIPTION
## Problem

Closes oasm-platform/open-asm#440

`WorkerDownloadTools` filtered the tool registry by OS (`runtime.GOOS`) but not by architecture (`runtime.GOARCH`). When both `arm64` and `amd64` archives are present in the registry, the worker downloaded all of them and extracted into the same directory. Since both archives contain binaries with identical filenames (e.g. `naabu`, `dnsx`), the last archive extracted silently overwrote the first.

Due to alphabetical ordering (`amd64` < `arm64`), `arm64` was always extracted last — meaning:
- **arm64 workers**: accidentally received the correct binary (arm64 wins)
- **amd64 workers**: broken — received the arm64 binary, which cannot execute on x86_64

## Fix

Add `filterByArch()` which selects only archives whose filename contains the current `runtime.GOARCH` value (e.g. `"arm64"`, `"amd64"`):

```go
osTools = filterByArch(registry.Linux, archKey)
```

A fallback to the full list is preserved so single-arch deployments — where no filename contains the arch string — continue to work without any changes to the registry.

## Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Only `amd64` tools in registry | amd64 worker works | amd64 worker works (fallback) |
| Only `arm64` tools in registry | arm64 worker works | arm64 worker works (fallback) |
| Both `amd64` + `arm64` in registry | arm64 wins (amd64 workers broken) | Each worker downloads its own arch ✅ |

## Related

- oasm-platform/open-asm#438 — added arm64 binaries to the registry (triggered this bug on amd64 workers)
- oasm-platform/open-asm#440 — tracks this issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tool selection now considers CPU architecture in addition to operating system, ensuring proper compatibility with multi-architecture distributions while preserving existing cache and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->